### PR TITLE
Add labyrinth minigame and points tracking

### DIFF
--- a/src/main/java/com/TNTStudios/deWaltCore/DeWaltCore.java
+++ b/src/main/java/com/TNTStudios/deWaltCore/DeWaltCore.java
@@ -1,18 +1,38 @@
 package com.TNTStudios.deWaltCore;
 
+import com.TNTStudios.deWaltCore.points.PointsManager;
 import com.TNTStudios.deWaltCore.registration.RegistrationListener;
 import com.TNTStudios.deWaltCore.scoreboard.ScoreboardListener;
+import com.TNTStudios.deWaltCore.minigames.laberinto.LaberintoBestTimeManager;
+import com.TNTStudios.deWaltCore.minigames.laberinto.LaberintoTimerCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class DeWaltCore extends JavaPlugin {
 
+    private static DeWaltCore instance;
+    private PointsManager pointsManager;
+    private LaberintoBestTimeManager bestTimeManager;
+    private LaberintoTimerCommand timerCommand;
+
+    public static DeWaltCore getInstance() {
+        return instance;
+    }
+
     @Override
     public void onEnable() {
+        instance = this;
 
-        getServer().getPluginManager().registerEvents(new ScoreboardListener(), this);
+        pointsManager = new PointsManager(this);
+        bestTimeManager = new LaberintoBestTimeManager(this);
+        bestTimeManager.load();
 
-        getServer().getPluginManager().registerEvents(new ScoreboardListener(), this);
+        timerCommand = new LaberintoTimerCommand(this, bestTimeManager, pointsManager);
 
+        getServer().getPluginManager().registerEvents(new ScoreboardListener(pointsManager), this);
+        getServer().getPluginManager().registerEvents(timerCommand, this);
+
+        getCommand("empezar").setExecutor(timerCommand);
+        getCommand("detener").setExecutor(timerCommand);
         //register apagado
         //getServer().getPluginManager().registerEvents(new RegistrationListener(), this);
     }
@@ -20,7 +40,8 @@ public final class DeWaltCore extends JavaPlugin {
 
     @Override
     public void onDisable() {
-
+        bestTimeManager.save();
+        pointsManager.saveAllPoints();
     }
 }
 

--- a/src/main/java/com/TNTStudios/deWaltCore/minigames/laberinto/LaberintoBestTimeManager.java
+++ b/src/main/java/com/TNTStudios/deWaltCore/minigames/laberinto/LaberintoBestTimeManager.java
@@ -1,0 +1,69 @@
+package com.TNTStudios.deWaltCore.minigames.laberinto;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scoreboard.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LaberintoBestTimeManager {
+    private final JavaPlugin plugin;
+    private final Map<String, Integer> bestTimesByName = new HashMap<>();
+
+    public LaberintoBestTimeManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        plugin.saveDefaultConfig();
+        plugin.reloadConfig();
+        ConfigurationSection sec = plugin.getConfig().getConfigurationSection("laberintoBestTimes");
+        if (sec != null) {
+            for (String name : sec.getKeys(false)) {
+                bestTimesByName.put(name, sec.getInt(name));
+            }
+        }
+    }
+
+    public void save() {
+        for (String name : bestTimesByName.keySet()) {
+            plugin.getConfig().set("laberintoBestTimes." + name, bestTimesByName.get(name));
+        }
+        plugin.saveConfig();
+    }
+
+    public int getBestTime(String name) {
+        return bestTimesByName.getOrDefault(name, -1);
+    }
+
+    public boolean updateBestTime(String name, int newTime) {
+        int current = getBestTime(name);
+        if (current == -1 || newTime < current) {
+            bestTimesByName.put(name, newTime);
+            return true;
+        }
+        return false;
+    }
+
+    public void showScoreboard(Player player) {
+        Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
+        Objective obj = board.registerNewObjective("laberinto_best", "dummy", ChatColor.DARK_AQUA + "Tu Mejor Tiempo");
+        obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+
+        int best = getBestTime(player.getName());
+        String line = (best == -1) ? ChatColor.YELLOW + "A\u00fan no has hecho un intento" : ChatColor.GREEN + format(best);
+        obj.getScore(line).setScore(1);
+        player.setScoreboard(board);
+    }
+
+    private String format(int seconds) {
+        int h = seconds / 3600;
+        int m = (seconds % 3600) / 60;
+        int s = seconds % 60;
+        return String.format("%02dh:%02dm:%02ds", h, m, s);
+    }
+}

--- a/src/main/java/com/TNTStudios/deWaltCore/minigames/laberinto/LaberintoTimerCommand.java
+++ b/src/main/java/com/TNTStudios/deWaltCore/minigames/laberinto/LaberintoTimerCommand.java
@@ -1,0 +1,169 @@
+package com.TNTStudios.deWaltCore.minigames.laberinto;
+
+import com.TNTStudios.deWaltCore.points.PointsManager;
+import com.TNTStudios.deWaltCore.scoreboard.DeWaltScoreboardManager;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class LaberintoTimerCommand implements CommandExecutor, Listener {
+    private final JavaPlugin plugin;
+    private final LaberintoBestTimeManager bestTimeManager;
+    private final PointsManager pointsManager;
+    private final Map<String, Integer> timers = new HashMap<>();
+    private final Map<String, BukkitRunnable> tasks = new HashMap<>();
+
+    public LaberintoTimerCommand(JavaPlugin plugin, LaberintoBestTimeManager bestTimeManager, PointsManager pointsManager) {
+        this.plugin = plugin;
+        this.bestTimeManager = bestTimeManager;
+        this.pointsManager = pointsManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Solo jugadores pueden usar este comando.");
+            return true;
+        }
+
+        if (!player.isOp()) {
+            player.sendMessage(ChatColor.RED + "No tienes permiso para usar este comando.");
+            return true;
+        }
+
+        String name = player.getName();
+        String cmd = command.getName();
+
+        if (cmd.equalsIgnoreCase("empezar")) {
+            if (tasks.containsKey(name)) {
+                player.sendMessage(ChatColor.RED + "\u00a1Tu Puedes!");
+                return true;
+            }
+            timers.put(name, 0);
+            player.sendTitle(ChatColor.GOLD + "Contador iniciado", "", 10, 70, 20);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1f, 1f);
+            BukkitRunnable task = new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (!timers.containsKey(name)) {
+                        cancel();
+                        tasks.remove(name);
+                        return;
+                    }
+                    int t = timers.get(name) + 1;
+                    timers.put(name, t);
+                    String formatted = format(t);
+                    player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.GREEN + "Tiempo transcurrido: " + formatted));
+                }
+            };
+            task.runTaskTimer(plugin, 20, 20);
+            tasks.put(name, task);
+        } else if (cmd.equalsIgnoreCase("detener")) {
+            if (!tasks.containsKey(name)) {
+                player.sendMessage(ChatColor.RED + "\u00a1Tu Puedes!");
+                return true;
+            }
+            tasks.get(name).cancel();
+            tasks.remove(name);
+
+            if (!timers.containsKey(name)) {
+                player.sendMessage(ChatColor.RED + "No hay tiempo registrado para detener.");
+                return true;
+            }
+            int total = timers.remove(name);
+            boolean improved = bestTimeManager.updateBestTime(name, total);
+            String formatted = format(total);
+            player.sendTitle(ChatColor.RED + "Tiempo detenido", ChatColor.YELLOW + "Tardaste " + formatted, 10, 70, 20);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1f, 1f);
+            bestTimeManager.showScoreboard(player);
+            bestTimeManager.save();
+
+            int pointsToAdd = calculatePoints(name, total, improved);
+            if (pointsToAdd > 0) {
+                pointsManager.addPoints(name, pointsToAdd, "laberinto");
+                int pos = pointsManager.getTopPosition(name);
+                int totalPts = pointsManager.getPoints(name);
+                DeWaltScoreboardManager.updateDefaultPage(player, pos, totalPts, false);
+            }
+
+            World world = player.getWorld();
+            Location spawn = new Location(world, -4.53, -38, 26.53, -90, 0);
+            player.teleport(spawn);
+        }
+        return true;
+    }
+
+    private int calculatePoints(String name, int newTime, boolean improvedNow) {
+        int best = bestTimeManager.getBestTime(name);
+        if (best == -1 || best == newTime && improvedNow) {
+            return 10; // first completion
+        }
+        // improvement scoring
+        int diffCount = 0;
+        File file = new File(plugin.getDataFolder(), "players/" + name + ".yml");
+        if (file.exists()) {
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+            diffCount = config.getInt("improvements.lab", 0);
+        }
+        int pts;
+        if (diffCount == 0) {
+            pts = 5;
+        } else if (diffCount == 1) {
+            pts = 2;
+        } else {
+            pts = 1;
+        }
+        if (improvedNow) {
+            diffCount++;
+        }
+        YamlConfiguration config = file.exists() ? YamlConfiguration.loadConfiguration(file) : new YamlConfiguration();
+        config.set("improvements.lab", diffCount);
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return pts;
+    }
+
+    private String format(int seconds) {
+        int h = seconds / 3600;
+        int m = (seconds % 3600) / 60;
+        int s = seconds % 60;
+        return String.format("%02dh:%02dm:%02ds", h, m, s);
+    }
+
+    @EventHandler
+    public void onSpawnCommand(PlayerCommandPreprocessEvent event) {
+        if (event.getMessage().equalsIgnoreCase("/spawn")) {
+            String name = event.getPlayer().getName();
+            if (tasks.containsKey(name)) {
+                tasks.get(name).cancel();
+                tasks.remove(name);
+                timers.remove(name);
+                event.getPlayer().sendMessage(ChatColor.RED + "Tiempo cancelado.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/TNTStudios/deWaltCore/points/PointsManager.java
+++ b/src/main/java/com/TNTStudios/deWaltCore/points/PointsManager.java
@@ -1,0 +1,92 @@
+package com.TNTStudios.deWaltCore.points;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+public class PointsManager {
+    private final JavaPlugin plugin;
+    private final File playersFolder;
+    private final Map<String, Integer> totalPoints = new HashMap<>();
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.of("America/Mexico_City"));
+
+    public PointsManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.playersFolder = new File(plugin.getDataFolder(), "players");
+        if (!playersFolder.exists()) {
+            playersFolder.mkdirs();
+        }
+        loadAllPoints();
+    }
+
+    private void loadAllPoints() {
+        File[] files = playersFolder.listFiles((dir, name) -> name.endsWith(".yml"));
+        if (files == null) return;
+        for (File file : files) {
+            String name = file.getName().substring(0, file.getName().length() - 4);
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+            int pts = config.getInt("points", 0);
+            totalPoints.put(name, pts);
+        }
+    }
+
+    public void saveAllPoints() {
+        for (String name : totalPoints.keySet()) {
+            savePlayer(name);
+        }
+    }
+
+    private void savePlayer(String name) {
+        File file = new File(playersFolder, name + ".yml");
+        YamlConfiguration config = file.exists() ? YamlConfiguration.loadConfiguration(file) : new YamlConfiguration();
+        config.set("points", totalPoints.getOrDefault(name, 0));
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int getPoints(String name) {
+        return totalPoints.getOrDefault(name, 0);
+    }
+
+    public void addPoints(String name, int amount, String minigame) {
+        int newTotal = getPoints(name) + amount;
+        totalPoints.put(name, newTotal);
+
+        File file = new File(playersFolder, name + ".yml");
+        YamlConfiguration config = file.exists() ? YamlConfiguration.loadConfiguration(file) : new YamlConfiguration();
+        config.set("points", newTotal);
+        List<Map<?, ?>> list = config.getMapList("history");
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("minigame", minigame);
+        entry.put("points", amount);
+        entry.put("time", formatter.format(Instant.now()));
+        list.add(entry);
+        config.set("history", list);
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int getTopPosition(String name) {
+        List<Map.Entry<String, Integer>> list = new ArrayList<>(totalPoints.entrySet());
+        list.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i).getKey().equalsIgnoreCase(name)) {
+                return i + 1;
+            }
+        }
+        return list.size() + 1;
+    }
+}

--- a/src/main/java/com/TNTStudios/deWaltCore/scoreboard/ScoreboardListener.java
+++ b/src/main/java/com/TNTStudios/deWaltCore/scoreboard/ScoreboardListener.java
@@ -1,6 +1,6 @@
 package com.TNTStudios.deWaltCore.scoreboard;
 
-import org.bukkit.Bukkit;
+import com.TNTStudios.deWaltCore.points.PointsManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,14 +8,19 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class ScoreboardListener implements Listener {
+    private final PointsManager pointsManager;
+
+    public ScoreboardListener(PointsManager pointsManager) {
+        this.pointsManager = pointsManager;
+    }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
 
         boolean hasUnlockedAll = checkIfUnlockedAll(player);
-        int topPosition = 0; // ← reemplazar con ranking real más adelante
-        int totalPoints = 0; // ← reemplazar con puntos reales
+        int totalPoints = pointsManager.getPoints(player.getName());
+        int topPosition = pointsManager.getTopPosition(player.getName());
 
         DeWaltScoreboardManager.showDefaultPage(player, topPosition, totalPoints, hasUnlockedAll);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,8 @@ authors: [ TNTStudios ]
 website: https://tntstudiosn.space/
 softdepend:
   - DecentHolograms
+commands:
+  empezar:
+    description: Inicia el timer del laberinto
+  detener:
+    description: Detiene el timer del laberinto


### PR DESCRIPTION
## Summary
- implement `PointsManager` to persist player points and ranking
- add labyrinth best time manager and timer command
- cancel active timer when player uses `/spawn`
- register new systems in `DeWaltCore`
- display player points on scoreboard
- define `empezar` and `detener` commands in plugin.yml

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68566275cc3c8332b911e0e657bcb511